### PR TITLE
Changed project and nuspec target to net46 instead of net462. Tested.

### DIFF
--- a/ConsoleApp1/App.config
+++ b/ConsoleApp1/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
     </startup>
 </configuration>

--- a/ConsoleApp1/ConsoleApp1.csproj
+++ b/ConsoleApp1/ConsoleApp1.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ConsoleApp1</RootNamespace>
     <AssemblyName>ConsoleApp1</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Sycade.BunqApi/Sycade.BunqApi.csproj
+++ b/Sycade.BunqApi/Sycade.BunqApi.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Sycade.BunqApi</RootNamespace>
     <AssemblyName>Sycade.BunqApi</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Sycade.BunqApi/Sycade.BunqApi.nuspec
+++ b/Sycade.BunqApi/Sycade.BunqApi.nuspec
@@ -15,6 +15,6 @@
   </metadata>
 
   <files>
-    <file src="bin\Release\Sycade.BunqApi.dll" target="lib\net462" />
+    <file src="bin\Release\Sycade.BunqApi.dll" target="lib\net46" />
   </files>
 </package>


### PR DESCRIPTION
Apps targeting .NET Frameworks with version lower than v4.6.2 don't accept NuGet package. Lowest possible .NET Framework for this project is v4.6.0 (build passes). 